### PR TITLE
Moved version to setup.py

### DIFF
--- a/piwigo/__init__.py
+++ b/piwigo/__init__.py
@@ -6,6 +6,3 @@
 """
 
 from piwigo.ws import Piwigo, WsNotExistException, WsErrorException, WsPiwigoException 
-
-__version_info__ = (1, 0, 1)
-__version__ = '.'.join([str(val) for val in  __version_info__])

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,8 @@
 import os
 from setuptools import setup, find_packages
 
-import piwigo
-
 NAME = "piwigo"
-VERSION = piwigo.__version__
+VERSION = "1.0.1"
 DESC = "piwigo description"
 URLPKG = "https://github.com/fraoustin/piwigo.git"
 


### PR DESCRIPTION
piwigo.py no longer imports itself to get the version. Importing your own code can make it uninstallable, because you product code will try to import dependencies, which aren't installed yet, because setup.py is what installs them.

see: https://stackoverflow.com/a/2058872/22806256